### PR TITLE
Fix peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,14 +22,14 @@
   },
   "homepage": "https://github.com/meetup/meetup-web-mocks#readme",
   "peerDependencies":{
-    "react": ">=15.3.2",
-    "react-addons-test-utils": ">=15.3.2",
-    "react-dom": ">=15.3.2",
-    "react-intl": ">=2.1.5",
-    "react-redux": ">=4.4.5",
-    "react-router": ">=2.7.0",
-    "redux": ">=3.5.2",
-    "rxjs": ">=5.0.0"
+    "react": ">=15.4.2",
+    "react-addons-test-utils": ">=15.4.1",
+    "react-dom": ">=15.4.1",
+    "react-intl": ">=2.2.3",
+    "react-redux": ">=5.0.2",
+    "react-router": ">=3.0.2",
+    "redux": ">=3.6.0",
+    "rxjs": ">=5.0.3"
   },
   "devDependencies": {
     "babel-cli": "6.18.0",
@@ -38,6 +38,14 @@
     "babel-preset-react": "6.16.0",
     "babel-preset-stage-2": "6.18.0",
     "eslint": "3.9.1",
-    "eslint-plugin-react": "6.3.0"
+    "eslint-plugin-react": "6.3.0",
+    "react": "15.4.2",
+    "react-addons-test-utils": "15.4.1",
+    "react-dom": "15.4.1",
+    "react-intl": "2.2.3",
+    "react-redux": "5.0.2",
+    "react-router": "3.0.2",
+    "redux": "3.6.0",
+    "rxjs": "5.0.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -22,14 +22,14 @@
   },
   "homepage": "https://github.com/meetup/meetup-web-mocks#readme",
   "peerDependencies":{
-    "react": ">=15.4.2",
-    "react-addons-test-utils": ">=15.4.1",
-    "react-dom": ">=15.4.1",
-    "react-intl": ">=2.2.3",
-    "react-redux": ">=5.0.2",
-    "react-router": ">=3.0.2",
-    "redux": ">=3.6.0",
-    "rxjs": ">=5.0.3"
+    "react": "^15.4.2",
+    "react-addons-test-utils": "^15.4.1",
+    "react-dom": "^15.4.1",
+    "react-intl": "^2.2.3",
+    "react-redux": "^5.0.2",
+    "react-router": "^3.0.2",
+    "redux": "^3.6.0",
+    "rxjs": "^5.0.3"
   },
   "devDependencies": {
     "babel-cli": "6.18.0",
@@ -38,14 +38,6 @@
     "babel-preset-react": "6.16.0",
     "babel-preset-stage-2": "6.18.0",
     "eslint": "3.9.1",
-    "eslint-plugin-react": "6.3.0",
-    "react": "15.4.2",
-    "react-addons-test-utils": "15.4.1",
-    "react-dom": "15.4.1",
-    "react-intl": "2.2.3",
-    "react-redux": "5.0.2",
-    "react-router": "3.0.2",
-    "redux": "3.6.0",
-    "rxjs": "5.0.3"
+    "eslint-plugin-react": "6.3.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -22,14 +22,14 @@
   },
   "homepage": "https://github.com/meetup/meetup-web-mocks#readme",
   "peerDependencies":{
-    "react": "^15.3.2",
-    "react-addons-test-utils": "^15.3.2",
-    "react-dom": "^15.3.2",
-    "react-intl": "^2.1.5",
-    "react-redux": "^4.4.5",
-    "react-router": "^2.7.0",
-    "redux": "^3.5.2",
-    "rxjs": "^5.0.0"
+    "react": ">=15.3.2",
+    "react-addons-test-utils": ">=15.3.2",
+    "react-dom": ">=15.3.2",
+    "react-intl": ">=2.1.5",
+    "react-redux": ">=4.4.5",
+    "react-router": ">=2.7.0",
+    "redux": ">=3.5.2",
+    "rxjs": ">=5.0.0"
   },
   "devDependencies": {
     "babel-cli": "6.18.0",


### PR DESCRIPTION
Fixes #12 


The alternate solution is to keep the `^` range, but update the version of react-redux and react-router. If we choose to do that, we will need to remember to bump the peerDependencies each time a major version bump happens in a consumer (seems unrealistic?).