### PR TITLE
Adding mock best topics

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -174,7 +174,7 @@ export const MOCK_EVENT = {
 	yes_rsvp_count: 23
 };
 
-export const MOCK_BEST_TOPIC = {
+export const MOCK_TOPIC = {
 	id: 16645,
 	name: 'Volunteering',
 	urlkey: 'volunteering',
@@ -196,7 +196,7 @@ export const MOCK_CATEGORY = {
 		base_url: 'http://photos1.meetupstatic.com'
 	},
 	category_ids: [4, 13],
-	best_topics: [MOCK_BEST_TOPIC]
+	best_topics: [MOCK_TOPIC]
 };
 
 export const MOCK_CATEGORIES = [MOCK_CATEGORY];

--- a/src/api.js
+++ b/src/api.js
@@ -174,13 +174,6 @@ export const MOCK_EVENT = {
 	yes_rsvp_count: 23
 };
 
-export const MOCK_TOPIC = {
-	id: 16645,
-	name: 'Volunteering',
-	urlkey: 'volunteering',
-	lang: 'en_US'
-};
-
 // Mock category sourced from https://www.meetup.com/meetup_api/docs/find/topic_categories/
 export const MOCK_CATEGORY = {
 	id: 552,
@@ -196,7 +189,12 @@ export const MOCK_CATEGORY = {
 		base_url: 'http://photos1.meetupstatic.com'
 	},
 	category_ids: [4, 13],
-	best_topics: [MOCK_TOPIC]
+	best_topics: [{
+		id: 16645,
+		name: 'Volunteering',
+		urlkey: 'volunteering',
+		lang: 'en_US'
+	}]
 };
 
 export const MOCK_CATEGORIES = [MOCK_CATEGORY];

--- a/src/api.js
+++ b/src/api.js
@@ -174,6 +174,13 @@ export const MOCK_EVENT = {
 	yes_rsvp_count: 23
 };
 
+export const MOCK_BEST_TOPIC = {
+	id: 16645,
+	name: 'Volunteering',
+	urlkey: 'volunteering',
+	lang: 'en_US'
+};
+
 // Mock category sourced from https://www.meetup.com/meetup_api/docs/find/topic_categories/
 export const MOCK_CATEGORY = {
 	id: 552,
@@ -188,7 +195,8 @@ export const MOCK_CATEGORY = {
 		type: 'event',
 		base_url: 'http://photos1.meetupstatic.com'
 	},
-	category_ids: [4, 13]
+	category_ids: [4, 13],
+	best_topics: [MOCK_BEST_TOPIC]
 };
 
 export const MOCK_CATEGORIES = [MOCK_CATEGORY];


### PR DESCRIPTION
https://meetup.atlassian.net/browse/WP-248

Need to add best_topics array to mock categories for use with testing the topics view in the register flow.

Relevant API method: https://www.meetup.com/meetup_api/docs/find/topic_categories/