### PR TITLE
remove notifs from default app state

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -6,10 +6,6 @@ import {
 import {
 	MOCK_COMM_APP_STATE
 } from './group/communication/app';
-import {
-	MOCK_NOTIFICATION_UNREAD,
-	MOCK_NOTIFICATION_READ
-} from './notifications/api';
 
 export const MOCK_APP_STATE = {
 	app: {
@@ -34,13 +30,6 @@ export const MOCK_APP_STATE = {
 		event: {
 			type: 'event',
 			value: MOCK_EVENT,
-		},
-		notifications: {
-			type: 'notifications',
-			value: [
-				MOCK_NOTIFICATION_UNREAD,
-				MOCK_NOTIFICATION_READ
-			]
 		},
 		...MOCK_COMM_APP_STATE
 	},


### PR DESCRIPTION
Removing notifications from default app state will make it easier to test empty states for notifications feature in `mup-web`.