### PR TITLE
prepublish not install

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "lint": "yarn run lint:base -- --fix",
     "lint:base": "eslint . --ext .js, .jsx",
     "modules:clean": "rm -rf node_modules",
-    "install": "yarn run build",
+    "prepublish": "yarn run build",
     "test": "yarn run lint:base"
   },
   "repository": {


### PR DESCRIPTION
I'm seeing the error below on an irregular basis. I'm going to back out of this for now so it can be studied in isolation.

```error /Users/mattk/code/meetup-web-components/node_modules/meetup-web-mocks: Command failed.
Exit code: 1
Command: sh
Arguments: -c yarn run build
Directory: /Users/mattk/code/meetup-web-components/node_modules/meetup-web-mocks
Output:
yarn run v0.22.0
$ babel src --out-dir lib --ignore test.js,test.jsx,story.jsx --source-maps
sh: babel: command not found
error Command failed with exit code 127.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```