### PR TITLE
add mock query with api request headers

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -116,7 +116,7 @@ export const mockQuery = ({ location, params }) => {
 
 export const mockQueryApiHeaders = ({ location, params }) => {
 	return {
-		type: 'group',
+		type: 'member',
 		endpoint: (params || {}).urlname || 'foo',
 		params: params,
 		meta: {
@@ -125,7 +125,7 @@ export const mockQueryApiHeaders = ({ location, params }) => {
 				'unread-messages',
 			]
 		},
-		ref: 'group'
+		ref: 'self'
 	};
 };
 

--- a/src/app.js
+++ b/src/app.js
@@ -114,6 +114,21 @@ export const mockQuery = ({ location, params }) => {
 	};
 };
 
+export const mockQueryApiHeaders = ({ location, params }) => {
+	return {
+		type: 'group',
+		endpoint: (params || {}).urlname || 'foo',
+		params: params,
+		meta: {
+			apiMetaheaders: [
+				'unread-notifications',
+				'unread-messages',
+			]
+		},
+		ref: 'group'
+	};
+};
+
 export const mockQueryBadType = ({ location, params }) => {
 	const type = 'lkajlhsdhljaskliub';
 	return { ...mockQuery({ location, params }), type };

--- a/src/app.js
+++ b/src/app.js
@@ -105,27 +105,13 @@ export const MOCK_MEANINGLESS_ACTION = {
 	payload: '/'
 };
 
-export const mockQuery = ({ location, params }) => {
+export const mockQuery = ({ location, params, apiMetaHeaders }) => {
 	return {
 		type: 'group',
 		endpoint: (params || {}).urlname || 'foo',
 		params: params,
+		meta: { apiMetaHeaders },
 		ref: 'group'
-	};
-};
-
-export const mockQueryApiHeaders = ({ location, params }) => {
-	return {
-		type: 'member',
-		endpoint: (params || {}).urlname || 'foo',
-		params: params,
-		meta: {
-			apiMetaheaders: [
-				'unread-notifications',
-				'unread-messages',
-			]
-		},
-		ref: 'self'
 	};
 };
 


### PR DESCRIPTION
Adds mock for `meta.apiMetaHeaders` usage in a query.

See also: https://www.meetup.com/meetup_api/docs/#meta-headers