### PR TITLE
Add link to MOCK_EVENT

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -268,6 +268,7 @@ export const MOCK_EVENT = {
 	utc_offset: 0,
 	visibility: 'public',
 	yes_rsvp_count: 23,
+	link: 'https://www.meetup.com/group/events/123456',
 };
 
 // Mock category sourced from https://www.meetup.com/meetup_api/docs/find/topic_categories/


### PR DESCRIPTION
Adding `link` to `MOCK_EVENT` for use in `mup-web`'s tests that involve `src/util/seoHelper.test.jsx`'s `generateEventLdJson`.