### PR TITLE
MW-2156: adding event/group w/o dynamic times, adding more mock event variations

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -355,3 +355,92 @@ export const MOCK_EVENT_SCHEDULE_RESPONSE_ERRORS = {
 		statusCode: 400
 	}
 };
+
+/*
+ * Shallow mocks that don't include dynamic dates
+ * for ease of use with snapshots.
+ */
+
+export const MOCK_SHALLOW_GROUP = {
+	id: MOCK_GROUP.id,
+	key_photo: MOCK_GROUP.key_photo,
+	name: MOCK_GROUP.name,
+	urlname: MOCK_GROUP.urlname,
+	members: MOCK_GROUP.members,
+	organizer: MOCK_GROUP.organizer,
+	link: MOCK_GROUP.link,
+	duotoneUrl: MOCK_GROUP.duotoneUrl,
+	group_photo: MOCK_GROUP.group_photo,
+	photo_gradient: MOCK_GROUP.photo_gradient,
+	plain_text_description: MOCK_GROUP.plain_text_description,
+	who: MOCK_GROUP.who,
+};
+export const MOCK_TIME = 1508279299118;
+export const MOCK_SHALLOW_MEMBER = { id: MOCK_CHAPTER_MEMBER.id };
+export const MOCK_SHALLOW_EVENT = {
+	id: '123456',
+	comment_count: 5,
+	created: MOCK_TIME,
+	description:
+		'The coolest event in the world during which we will run and dance and sing\n\t<script>alert("bad time")</script>, \uD83D\uDE0A, &lt;blink&gt;what what&lt;blink&gt; this is getting\n\tlonger than it needs to be why am I still typing omg',
+	duration: 3600000,
+	name: 'So much fun',
+	rsvp_sample: [
+		{
+			created: 1462833255609,
+			id: 1234,
+			member: MOCK_SHALLOW_MEMBER,
+			updated: 1462833255610,
+		},
+		{
+			created: 1462833255609,
+			id: 2345,
+			member: { ...MOCK_SHALLOW_MEMBER, id: 8912894 },
+			updated: 1462833255610,
+		},
+		{
+			created: 1462833255609,
+			id: 3456,
+			member: { ...MOCK_SHALLOW_MEMBER, id: 899828 },
+			updated: 1462833255610,
+		},
+	],
+	venue: MOCK_VENUE,
+	how_to_find_us: 'how to find us',
+	event_hosts: [],
+	fee: {
+		amount: 10,
+		currency: 'USD',
+	},
+	rsvpable: true,
+	group: MOCK_SHALLOW_GROUP,
+	self: {
+		actions: ['rsvp'],
+		pay_status: 'none',
+		rsvp: {},
+	},
+	status: 'upcoming',
+	time: MOCK_TIME,
+	utc_offset: 0,
+	visibility: 'public',
+	yes_rsvp_count: 23,
+};
+
+export const MOCK_EVENTS = [
+	{ ...MOCK_SHALLOW_EVENT, id: '1111', status: 'upcoming' },
+	{ ...MOCK_SHALLOW_EVENT, id: '2222', status: 'upcoming' },
+	{ ...MOCK_SHALLOW_EVENT, id: '3333', status: 'upcoming' },
+	{ ...MOCK_SHALLOW_EVENT, id: '4444', status: 'upcoming' },
+];
+
+export const MOCK_PAST_EVENTS = [
+	{ ...MOCK_SHALLOW_EVENT, id: '5555', status: 'past' },
+	{ ...MOCK_SHALLOW_EVENT, id: '6666', status: 'past' },
+	{ ...MOCK_SHALLOW_EVENT, id: '7777', status: 'past' },
+	{ ...MOCK_SHALLOW_EVENT, id: '8888', status: 'past' },
+];
+
+export const UPCOMING_EVENT = { ...MOCK_EVENTS[0], status: 'upcoming' };
+export const PROPOSED_EVENT = { ...MOCK_EVENTS[1], status: 'proposed' };
+export const PAST_EVENT = { ...MOCK_EVENTS[2], status: 'past' };
+


### PR DESCRIPTION
Adding events list and common event types for event list testing. Also adding a smaller event and group object for less comprehensive shallow testing.

* MOCK_EVENTS
* MOCK_PAST_EVENTS
* MOCK_SHALLOW_EVENT
* MOCK_SHALLOW_GROUP
* UPCOMING_EVENT
* PAST_EVENT
* PROPOSED_EVENT
* MOCK_TIME