### PR TITLE
Hardcode value of event_sample:time

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -62,7 +62,7 @@ export const MOCK_GROUP = {
 		{
 			id: 1234,
 			name: 'Sample event',
-			time: new Date().getTime(),
+			time: '1508959523994',
 			yes_rsvp_count: 50,
 		},
 	],


### PR DESCRIPTION
This has gotten me a few times in mup-web where I want to use a MOCK_EVENT in my props, but snapshot tests fail because of the updating timestamp in event_sample/time. 