### PR TITLE
add thumb link to member mock

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -3,6 +3,7 @@ export const MOCK_MEMBER = {
 	id: 1243,
 	photo: {
 		photo_link: 'http://placekitten.com/g/400/400',
+		thumb_link: 'http://placekitten.com/g/200/200',
 	},
 };
 


### PR DESCRIPTION
Adds `thumb_link` to the member mock, which is used by the `AvatarMember` component